### PR TITLE
Refactor light controller v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ It retrieves the loxone StructureFile and tries to map all items to HomeKit acce
 |`IntercomV2` | Doorbell, MotionSensor, Camera | Auto
 |`IRoomControllerV2` | Thermostat | Auto
 |`Lock` | LockMechanism | Manual | A switch with an alias that is defined in the config.
-|`MoodSwitch` | Switch | Auto | all LightControllerV2 moods are maped to a seperate switch.
+|`MoodSwitch` | Switch Group | Auto | all LightControllerV2 moods are mapped to a Switch Group as a seperate switch.
 |`Motion` | MotionSensor | Manual | Requires an alias in the config.
 |`PresenceDetector` | OccupancySensor | Auto
 |`Switch` | Switch, Outlet, or Lightbulb | Auto

--- a/src/LoxoneAccessory.ts
+++ b/src/LoxoneAccessory.ts
@@ -11,8 +11,8 @@ import { Gate } from './items/Gate';
 import { Humidiy } from './items/Humidity';
 import { IntercomV2 } from './items/IntercomV2';
 import { IRoomControllerV2 } from './items/IRoomControllerV2';
+import { LightControllerV2 } from './items/LightControllerV2';
 import { Lock } from './items/Lock';
-import { MoodSwitch } from './items/MoodSwitch';
 import { Motion } from './items/Motion';
 import { PresenceDetector } from './items/PresenceDetector';
 import { Switch } from './items/Switch';
@@ -20,17 +20,47 @@ import { Ventilation } from './items/Ventilation';
 
 export class LoxoneAccessory {
 
+  // Items supported by this Platform
+  private SupportedItems = [
+    'Alarm',
+    'Brightness',
+    'ColorPickerV2',
+    'Dimmer',
+    'Gate',
+    'Humidity',
+    'IntercomV2',
+    'IRoomControllerV2',
+    'LightControllerV2',
+    'Lock',
+    'Motion',
+    'PresenceDetector',
+    'Switch',
+    'Ventilation',
+  ];
+
   constructor(
     private readonly platform: LoxonePlatform,
     private readonly device: Control,
   ) {
+
+    if (this.platform.LoxoneItemCount >= 149) {
+      this.platform.log.info('[LoxoneAccessory] Maximum number of supported HomeKit items reached. Stop mapping Items.');
+      return;
+    }
+
+    if (!this.SupportedItems.includes(this.device.type)) {
+      this.platform.log.debug(`[[LoxoneAccessory] Skipping Unsupported item: ${this.device.name} with type ${this.device.type}`);
+      return;
+    }
+
+    this.platform.log.debug(`[mapLoxoneItems][${this.platform.LoxoneItemCount}] Found: ${this.device.name} with type ${this.device.type}`);
 
     const uuid = this.platform.api.hap.uuid.generate(this.device.uuidAction);
     const existingAccessory = this.platform.accessories.find(accessory => accessory.UUID === uuid);
 
     if (existingAccessory) {
       // the accessory already exists
-      this.platform.log.debug('[LoxoneAccesory] Item already mapped. Restoring accessory from cache:', existingAccessory.displayName);
+      this.platform.log.debug('[LoxoneAccessory] Item already mapped. Restoring accessory from cache:', existingAccessory.displayName);
 
       // update the accessory.context
       existingAccessory.context.device = this.device;
@@ -58,6 +88,7 @@ export class LoxoneAccessory {
       // link the accessory to your platform
       this.platform.api.registerPlatformAccessories('homebridge-loxone-proxy', 'LoxonePlatform', [accessory]);
     }
+    this.platform.LoxoneItemCount++;
   }
 
   mapLoxoneItem(accessory: PlatformAccessory) {
@@ -75,56 +106,42 @@ export class LoxoneAccessory {
       case 'Alarm':
         new Alarm(this.platform, accessory);
         break;
-
       case 'Brightness':
         new Brightness(this.platform, accessory);
         break;
-
       case 'ColorPickerV2':
         new ColorPickerV2(this.platform, accessory);
         break;
-
-
       case 'IntercomV2':
         new IntercomV2(this.platform, accessory);
         break;
-
       case 'Humidity':
         new Humidiy(this.platform, accessory);
         break;
-
       case 'Switch':
         new Switch(this.platform, accessory);
         break;
-
+      case 'LightControllerV2':
+        new LightControllerV2(this.platform, accessory);
+        break;
       case 'Lock':
         new Lock(this.platform, accessory);
         break;
-
       case 'Motion':
         new Motion(this.platform, accessory);
         break;
-
       case 'PresenceDetector':
         new PresenceDetector(this.platform, accessory);
         break;
-
       case 'Gate':
         new Gate(this.platform, accessory);
         break;
-
       case 'Dimmer':
         new Dimmer(this.platform, accessory);
         break;
-
-      case 'MoodSwitch':
-        new MoodSwitch(this.platform, accessory);
-        break;
-
       case 'IRoomControllerV2':
         new IRoomControllerV2(this.platform, accessory);
         break;
-
       case 'Ventilation':
         new Ventilation(this.platform, accessory);
         break;

--- a/src/LoxonePlatform.ts
+++ b/src/LoxonePlatform.ts
@@ -61,34 +61,14 @@ export class LoxonePlatform implements DynamicPlatformPlugin {
 
       const LoxoneItem = config.controls[ItemUuid];
 
-      if (LoxoneItem.type === 'LightControllerV2') {
-        this.parseLoxoneLightController(LoxoneItem);
-      } //else {
-        this.LoxoneItems[ItemUuid] = LoxoneItem;
-        this.LoxoneItems[ItemUuid].room = this.LoxoneRooms[LoxoneItem.room];
-        this.LoxoneItems[ItemUuid].cat = this.LoxoneCats[LoxoneItem.cat];
-        this.LoxoneItems[ItemUuid].type = this.checkLoxoneType(LoxoneItem);
-      //}
+      this.LoxoneItems[ItemUuid] = LoxoneItem;
+      this.LoxoneItems[ItemUuid].room = this.LoxoneRooms[LoxoneItem.room];
+      this.LoxoneItems[ItemUuid].cat = this.LoxoneCats[LoxoneItem.cat];
+      this.LoxoneItems[ItemUuid].type = this.checkLoxoneType(LoxoneItem);
     }
 
     this.mapLoxoneItems(this.LoxoneItems);  // Map all discover Loxone Items
     this.removeUnmappedAccessories(); // Remove Cached Items which are removed from Loxone
-  }
-
-  parseLoxoneLightController(LightControllerV2: Control) {
-
-    // Create individual Lights
-    for (const childUuid in LightControllerV2.subControls) {
-
-      const LightItem = LightControllerV2.subControls[childUuid];
-      if (!(LightItem.uuidAction.indexOf('/masterValue') !== -1) || (LightItem.uuidAction.indexOf('/masterColor')) !== -1) {
-        this.LoxoneItems[childUuid] = LightItem;
-        this.LoxoneItems[childUuid].room = this.LoxoneRooms[LightControllerV2.room];
-        this.LoxoneItems[childUuid].cat = this.LoxoneCats[LightControllerV2.cat];
-        this.LoxoneItems[childUuid].type = this.checkLoxoneType(LightItem);
-      }
-    }
-    return;
   }
 
   checkLoxoneType(LoxoneItem: Control) {

--- a/src/LoxonePlatform.ts
+++ b/src/LoxonePlatform.ts
@@ -58,9 +58,7 @@ export class LoxonePlatform implements DynamicPlatformPlugin {
 
     // Loxone Items
     for (const ItemUuid in config.controls) {
-
       const LoxoneItem = config.controls[ItemUuid];
-
       this.LoxoneItems[ItemUuid] = LoxoneItem;
       this.LoxoneItems[ItemUuid].room = this.LoxoneRooms[LoxoneItem.room];
       this.LoxoneItems[ItemUuid].cat = this.LoxoneCats[LoxoneItem.cat];

--- a/src/items/LightControllerV2.ts
+++ b/src/items/LightControllerV2.ts
@@ -1,7 +1,7 @@
 import { PlatformAccessory } from 'homebridge';
 import { LoxonePlatform } from '../LoxonePlatform';
-import { Control } from '../structure/LoxAPP3';
 import { LoxoneAccessory } from '../LoxoneAccessory';
+import { Control } from '../structure/LoxAPP3';
 import { MoodSwitch } from './MoodSwitch';
 
 export class LightControllerV2 {
@@ -13,10 +13,8 @@ export class LightControllerV2 {
   ) {
 
     this.device = this.accessory.context.device;
-
     this.RegisterMoodSwitches();
     this.RegisterChildItems();
-
   }
 
   // Create Mood Switches if enabled in config

--- a/src/items/LightControllerV2.ts
+++ b/src/items/LightControllerV2.ts
@@ -24,7 +24,7 @@ export class LightControllerV2 {
       for (const mood of moods) {
         if (mood.id !== 778) {
           const MoodSwitchItem = Object.assign({}, this.device);
-          MoodSwitchItem.name = `[${this.device.room}] ${mood.name}`;
+          MoodSwitchItem.name = `${mood.name}`;
           MoodSwitchItem.cat = mood.id;
           MoodSwitchItem.details = {};
           MoodSwitchItem.subControls = {};

--- a/src/items/LightControllerV2.ts
+++ b/src/items/LightControllerV2.ts
@@ -1,0 +1,39 @@
+import { PlatformAccessory } from 'homebridge';
+import { LoxonePlatform } from '../LoxonePlatform';
+import { Control } from '../structure/LoxAPP3';
+import { MoodSwitch } from './MoodSwitch';
+
+export class LightControllerV2 {
+  private device: Control;
+
+  constructor(
+    private readonly platform: LoxonePlatform,
+    private readonly accessory: PlatformAccessory,
+  ) {
+
+    this.device = this.accessory.context.device;
+
+    //this.LoxoneListener();
+    this.RegisterMoodSwitches();
+
+  }
+
+  // Create Mood Switches if enabled in config
+  RegisterMoodSwitches = () => {
+    if (this.platform.config.options.MoodSwitches === 'enabled') {
+      const moods = JSON.parse(this.platform.LoxoneHandler.getLastCachedValue(this.device.states.moodList));
+      for (const mood of moods) {
+        if (mood.name !== 'Uit') {
+
+          const MoodSwitchItem = Object.assign({}, this.device);
+
+          MoodSwitchItem.name = `[${this.device.room}] ${mood.name}`;
+          MoodSwitchItem.cat = mood.id;
+          MoodSwitchItem.details = {};
+          MoodSwitchItem.subControls = {};
+          new MoodSwitch(this.platform, this.accessory, MoodSwitchItem);
+        }
+      }
+    }
+  };
+}

--- a/src/items/LightControllerV2.ts
+++ b/src/items/LightControllerV2.ts
@@ -1,6 +1,7 @@
 import { PlatformAccessory } from 'homebridge';
 import { LoxonePlatform } from '../LoxonePlatform';
 import { Control } from '../structure/LoxAPP3';
+import { LoxoneAccessory } from '../LoxoneAccessory';
 import { MoodSwitch } from './MoodSwitch';
 
 export class LightControllerV2 {
@@ -13,8 +14,8 @@ export class LightControllerV2 {
 
     this.device = this.accessory.context.device;
 
-    //this.LoxoneListener();
     this.RegisterMoodSwitches();
+    this.RegisterChildItems();
 
   }
 
@@ -23,16 +24,26 @@ export class LightControllerV2 {
     if (this.platform.config.options.MoodSwitches === 'enabled') {
       const moods = JSON.parse(this.platform.LoxoneHandler.getLastCachedValue(this.device.states.moodList));
       for (const mood of moods) {
-        if (mood.name !== 'Uit') {
-
+        if (mood.id !== 778) {
           const MoodSwitchItem = Object.assign({}, this.device);
-
           MoodSwitchItem.name = `[${this.device.room}] ${mood.name}`;
           MoodSwitchItem.cat = mood.id;
           MoodSwitchItem.details = {};
           MoodSwitchItem.subControls = {};
           new MoodSwitch(this.platform, this.accessory, MoodSwitchItem);
         }
+      }
+    }
+  };
+
+  // Create Mood Switches if enabled in config
+  RegisterChildItems = () => {
+    // Create individual Lights
+    for (const childUuid in this.device.subControls) {
+
+      const LightItem = this.device.subControls[childUuid];
+      if (!(LightItem.uuidAction.indexOf('/masterValue') !== -1) || (LightItem.uuidAction.indexOf('/masterColor')) !== -1) {
+        new LoxoneAccessory(this.platform, LightItem);
       }
     }
   };

--- a/src/items/LightControllerV2.ts
+++ b/src/items/LightControllerV2.ts
@@ -40,9 +40,10 @@ export class LightControllerV2 {
   RegisterChildItems = () => {
     // Create individual Lights
     for (const childUuid in this.device.subControls) {
-
       const LightItem = this.device.subControls[childUuid];
       if (!(LightItem.uuidAction.indexOf('/masterValue') !== -1) || (LightItem.uuidAction.indexOf('/masterColor')) !== -1) {
+        LightItem.room = this.device.room;
+        LightItem.cat = this.device.cat;
         new LoxoneAccessory(this.platform, LightItem);
       }
     }

--- a/src/items/MoodSwitch.ts
+++ b/src/items/MoodSwitch.ts
@@ -24,6 +24,9 @@ export class MoodSwitch {
 
     this.LoxoneListener();
 
+    this.service.setCharacteristic(this.platform.Characteristic.Name, this.device.name);
+    this.service.setCharacteristic(this.platform.Characteristic.ConfiguredName, this.device.name);
+
     this.service.getCharacteristic(this.platform.Characteristic.On)
       .onSet(this.setOn.bind(this))
       .onGet(this.getOn.bind(this));

--- a/src/items/MoodSwitch.ts
+++ b/src/items/MoodSwitch.ts
@@ -13,13 +13,14 @@ export class MoodSwitch {
   constructor(
     private readonly platform: LoxonePlatform,
     private readonly accessory: PlatformAccessory,
+    private readonly MoodSwitch: Control,
   ) {
 
-    this.device = this.accessory.context.device;
+    this.device = MoodSwitch;
 
     this.service =
-      this.accessory.getService(this.platform.Service.Switch) ||
-      this.accessory.addService(this.platform.Service.Switch);
+      this.accessory.getService(this.device.name) ||
+      this.accessory.addService(this.platform.Service.Switch, this.device.name, `${this.device.uuidAction}/${this.device.cat}`);
 
     this.LoxoneListener();
 

--- a/src/items/MoodSwitch.ts
+++ b/src/items/MoodSwitch.ts
@@ -25,8 +25,8 @@ export class MoodSwitch {
     this.LoxoneListener();
 
     this.service.getCharacteristic(this.platform.Characteristic.On)
-      .onSet(this.setOn.bind(this))  // SET - bind to the `setOn` method below
-      .onGet(this.getOn.bind(this)); // GET - bind to the `getOn` method below
+      .onSet(this.setOn.bind(this))
+      .onGet(this.getOn.bind(this));
   }
 
   // Register a listener to be notified of changes in this items value


### PR DESCRIPTION
Use LightControllerV2 as a base item and map lights and switches from here.
Mood switches are combined as a single Accessory to limit the amount of items.
Because all moodswitches are now part of the LightControllerV2 accessory, the are grouped together in HomeKit