### PR TITLE
Enable HKSV prebuffer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The following list displays all supported itemtypes supported by this plugin.
 | `Dimmer, EIBDimmer` | Lightbulb | Auto | Individual Dimmers, or items parsed from LightControllerV2.
 |`Gate` | GarageDoorOpener | Auto
 |`Humidity` | HumiditySensor | Auto | InfoOnlyAnalog Item. Tries to map based on its format. Can be overridden with a mapping.
-|`Intercom` | Doorbell, Camera | Auto | Includes basic motion detection for HKSV
-|`IntercomV2` | Doorbell, MotionSensor, Camera | Auto | "Use in userinterface" has to be enabled on the MotionSensor for it to be detected. Built‑in motion detection for HKSV
+|`Intercom` | Doorbell, Camera | Auto | Full HKSV support with prebuffered recording
+|`IntercomV2` | Doorbell, MotionSensor, Camera | Auto | "Use in userinterface" has to be enabled on the MotionSensor for it to be detected. Full HKSV support with prebuffered recording
 |`IRoomControllerV2` | Thermostat | Auto
 |`Jalousie` | Window Covering | Auto
 |`Leak` | LeakSensor | Manual | InfoOnlyDigital Item. Requires a mapping.

--- a/src/homekit/services/Camera.ts
+++ b/src/homekit/services/Camera.ts
@@ -69,7 +69,7 @@ export class CameraService implements CameraStreamingDelegate, CameraRecordingDe
 
   private preBuffer: PreBufferEntry[] = [];
   private preBufferDuration = 4000; // 4s prebuffer
-  private preBufferSession?: { server: Server; process: ChildProcess };
+  private preBufferSession?: { server?: Server; process: ChildProcess };
   private snapshotPromise?: Promise<Buffer>;
 
   private pendingSessions: Map<string, {
@@ -171,51 +171,40 @@ export class CameraService implements CameraStreamingDelegate, CameraRecordingDe
       this.log.debug('Reusing existing CameraController', this.cameraName);
       this.recordingConfig = recordingConfig;
     }
-    //this.startPreBuffer();
+    this.startPreBuffer().catch(err => this.log.warn(`Prebuffer failed: ${err}`));
     platform.api.on('shutdown', () => this.stopAll());
   }
 
   private async startPreBuffer(): Promise<void> {
     const args = [
       '-headers', `Authorization: Basic ${this.base64auth}\r\n`,
-      '-use_wallclock_as_timestamps', '1',
-      '-probesize', '32',
-      '-analyzeduration', '0',
-      '-fflags', 'nobuffer',
-      '-flags', 'low_delay',
-      '-max_delay', '0',
       '-i', this.streamUrl,
-      '-f', 'mjpeg',
-      '-c:v', 'libx264', '-preset', 'ultrafast', '-tune', 'zerolatency', '-r', '25',
-      '-bsf:v', 'h264_mp4toannexb',
-      '-f', 'rawvideo',
-      'tcp://127.0.0.1:',
+      '-f', 'lavfi', '-i', 'anullsrc=channel_layout=mono:sample_rate=32000',
+      '-c:v', 'libx264', '-c:a', 'aac', '-b:a', '64k',
+      '-map', '0:v:0', '-map', '1:a:0',
+      '-movflags', 'frag_keyframe+empty_moov+default_base_moof',
+      '-f', 'mp4', '-'
     ];
 
-    const server = createServer(async (socket) => {
-      server.close();
-      socket.on('data', (data) => {
+    const cp = spawn('ffmpeg', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    cp.stderr?.on('data', (data) => this.log.debug(`PreBuffer FFmpeg stderr: ${data}`));
+    const generator = this.parseFragmentedMP4(cp.stdout as Readable);
+    this.preBufferSession = { process: cp };
+
+    (async () => {
+      for await (const atom of generator) {
         const now = Date.now();
-        this.log.debug(`Pre-buffer data received: ${data.length} bytes`);
-        this.preBuffer.push({ atom: { header: Buffer.alloc(0), type: 'raw', length: data.length, data }, time: now });
+        this.preBuffer.push({ atom, time: now });
         this.preBuffer = this.preBuffer.filter(entry => entry.time > now - this.preBufferDuration);
-        if (this.preBuffer.length > 100) {
+        if (this.preBuffer.length > 150) {
           this.preBuffer.shift();
         }
-        this.log.debug(`PreBuffer updated: ${this.preBuffer.length} entries`);
-      });
-    });
-
-    const port = await this.listenServer(server);
-    args[args.length - 1] += port;
-
-    const cp = spawn('ffmpeg', args, { stdio: ['ignore', 'ignore', 'pipe'] });
-    cp.stderr?.on('data', (data) => this.log.debug(`PreBuffer FFmpeg stderr: ${data}`));
+      }
+    })();
     cp.on('exit', (code) => {
       this.preBuffer = [];
       this.log.debug(`Pre-buffer process exited with code ${code}`, this.cameraName);
     });
-    this.preBufferSession = { server, process: cp };
   }
 
   private async listenServer(server: Server): Promise<number> {
@@ -486,6 +475,9 @@ export class CameraService implements CameraStreamingDelegate, CameraRecordingDe
     }));
 
     const getMotionState = () => this.hksvMotionSensor.getCharacteristic(this.hap.Characteristic.MotionDetected).value;
+    for (const entry of this.preBuffer) {
+      yield { data: Buffer.concat([entry.atom.header, entry.atom.data]), isLast: false };
+    }
     for await (const box of generator) {
       yield { data: Buffer.concat([box.header, box.data]), isLast: !getMotionState() };
       if (!getMotionState()) {
@@ -521,7 +513,7 @@ export class CameraService implements CameraStreamingDelegate, CameraRecordingDe
 
   private stopAll(): void {
     this.preBufferSession?.process.kill();
-    this.preBufferSession?.server.close();
+    this.preBufferSession?.server?.close();
     this.ongoingSessions.forEach(session => {
       session.mainProcess?.kill();
       session.socket?.close();


### PR DESCRIPTION
## Summary
- implement a prebuffer for HKSV recordings
- start the prebuffer automatically for cameras
- include buffered fragments at the start of recordings
- document full HKSV support

## Testing
- `npm run build` *(fails: rimraf not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_685efb9b9c1c83249126127194fc8e31