### PR TITLE
Enable HKSV prebuffer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The following list displays all supported itemtypes supported by this plugin.
 | `Dimmer, EIBDimmer` | Lightbulb | Auto | Individual Dimmers, or items parsed from LightControllerV2.
 |`Gate` | GarageDoorOpener | Auto
 |`Humidity` | HumiditySensor | Auto | InfoOnlyAnalog Item. Tries to map based on its format. Can be overridden with a mapping.
-|`Intercom` | Doorbell, Camera | Auto | Includes basic motion detection for HKSV
-|`IntercomV2` | Doorbell, MotionSensor, Camera | Auto | "Use in userinterface" has to be enabled on the MotionSensor for it to be detected. Built‑in motion detection for HKSV
+|`Intercom` | Doorbell, Camera | Auto | Full HKSV support with prebuffered recording
+|`IntercomV2` | Doorbell, MotionSensor, Camera | Auto | "Use in userinterface" has to be enabled on the MotionSensor for it to be detected. Full HKSV support with prebuffered recording
 |`IRoomControllerV2` | Thermostat | Auto
 |`Jalousie` | Window Covering | Auto
 |`Leak` | LeakSensor | Manual | InfoOnlyDigital Item. Requires a mapping.


### PR DESCRIPTION
## Summary
- implement a prebuffer for HKSV recordings
- start the prebuffer automatically for cameras
- include buffered fragments at the start of recordings
- document full HKSV support
- fix HKSV prebuffer process

## Testing
- `npm run build` *(fails: rimraf not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_b_685efb9b9c1c83249126127194fc8e31