### PR TITLE
fix: ColorLightBulb setOn(true) does not send command to Miniserver

### DIFF
--- a/src/homekit/services/ColorLightBulb.ts
+++ b/src/homekit/services/ColorLightBulb.ts
@@ -130,6 +130,10 @@ export class ColorLightBulb extends LightBulb {
     if (!value) {
       this.State.Brightness = 0;
       this.setColorState();
+    } else if (this.State.Brightness === 0) {
+      this.State.Brightness = 100;
+      this.State.On = true;
+      this.setColorState();
     }
   }
 


### PR DESCRIPTION
## Problem

When turning on a ColorPickerV2 light from HomeKit (e.g. via Siri or the Home app), the light does not physically turn on. The Home app shows it as "on", but no command is sent to the Loxone Miniserver.

Turning **off** works correctly, and changing the **color** also works (because `setHue`/`setSaturation` call `setColorState()`).

## Root Cause

In `ColorLightBulb.setOn()`, only the `false` (off) case is handled:

```ts
async setOn(value: CharacteristicValue): Promise<void> {
        this.State.Brightness = 0;
        this.setColorState();
    }
    // ON case: nothing happens!
}
```

## Fix

When `setOn(true)` is called and brightness is currently 0, restore brightness to 100% and call `setColorState()` to send the `hsv()` command:

```ts
async setOn(value: CharacteristicValue): Promise<void> {
        this.State.Brightness = 0;
        this.setColorState();
    } else if (this.State.Brightness === 0) {
        this.State.Brightness = 100;
        this.State.On = true;
        this.setColorState();
    }
}
```

The `else if (this.State.Brightness === 0)` guard avoids sending redundant commands when HomeKit re-confirms an already-on state.

## Testing

Tested on:
- Loxone Miniserver firmware **17.0.3.31**
- **Touch Nightlight Air** devices (RGBW via ColorPickerV2)
- Homebridge v1.11.4, homebridge-loxone-proxy v1.12.1
- Both on/off toggle and color changes work correctly after the fix