### PR TITLE
fix(intercom): skip stale service pruning on Intercom accessories

### DIFF
--- a/src/LoxoneAccessory.ts
+++ b/src/LoxoneAccessory.ts
@@ -151,6 +151,11 @@ export class LoxoneAccessory {
    * services linger and surface as duplicate tiles in HomeKit.
    */
   private pruneStaleServices(kept: Set<Service>): void {
+    // Camera and motion sensor are added in afterSetup(); pruning here breaks HomeKit camera.
+    if (this.device.type === 'Intercom' || this.device.type === 'IntercomV2') {
+      return;
+    }
+
     const protectedTypes = new Set([
       this.platform.Service.AccessoryInformation.UUID,
       this.platform.Service.ServiceLabel.UUID,


### PR DESCRIPTION
Intercom V1/V2 add camera and motion sensor asynchronously in afterSetup(). Guard pruneStaleServices even when pruning is enabled elsewhere.